### PR TITLE
Unsigned arithmetic in vn function

### DIFF
--- a/src/com/iwebpp/crypto/TweetNacl.java
+++ b/src/com/iwebpp/crypto/TweetNacl.java
@@ -826,7 +826,7 @@ public final class TweetNacl {
 			int n)
 	{
 		int i,d = 0;
-		for (i = 0; i < n; i ++) d |= x[i+xoff]^y[i+yoff];
+		for (i = 0; i < n; i ++) d |= (x[i+xoff]&0xff) ^ (y[i+yoff]&0xff);
 		return (1 & ((d - 1) >>> 8)) - 1;
 	}
 

--- a/src/com/iwebpp/crypto/TweetNaclFast.java
+++ b/src/com/iwebpp/crypto/TweetNaclFast.java
@@ -840,7 +840,7 @@ public final class TweetNaclFast {
 			int n)
 	{
 		int i,d = 0;
-		for (i = 0; i < n; i ++) d |= x[i+xoff]^y[i+yoff];
+		for (i = 0; i < n; i ++) d |= (x[i+xoff]&0xff) ^ (y[i+yoff]&0xff);
 		return (1 & ((d - 1) >>> 8)) - 1;
 	}
 


### PR DESCRIPTION
vn function is used to verify encryption and it signal if keys don't match. If you try decrypt with wrong key, the code don't return a null as expected. Making vn work with unsigned arithmetic like I did all methods return null with wrong keys