### PR TITLE
In TweetNaclFast.java, added additional methods for Box' box, open, a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ TweetNacl in Java
 * decryption: message = box.open(cipher);
 * Nonce MUST be unique for ever message passed between same peers
 
+As an alternative, the nonce can be omitted from the Box() call, and passed in the box and open calls, like:
+
+* byte [] nonce = new byte[nonceLength], randombytes(theNonce, nonceLength);
+* Box.KeyPair kp = Box.keyPair(), kp = Box.keyPair_fromSecretKey(sk)
+* Box box = new Box(theirPublicKey, mySecretKey);
+* encryption: cipher = box.box(message, nonce);
+* decryption: message = box.open(cipher, nonce);
+
+
 
 #### Secret key authenticated encryption
 
@@ -20,6 +29,13 @@ TweetNacl in Java
 * encryption: cipher = sbox.box(message);
 * decryption: message = sbox.open(cipher);
 * Nonce MUST be unique for ever message passed between same peers
+
+As an alternative, the nonce can be omitted from the SecretBox() call, and passed in the box and open calls, like:
+
+* byte [] nonce = new byte[nonceLength], randombytes(theNonce, nonceLength);
+* SecretBox sbox = new SecretBox(sharedKey);
+* cipher = sbox.box(message, nonce);
+* decryption: message = sbox.open(cipher, nonce);
 
 
 ### Signature

--- a/src/com/iwebpp/crypto/TweetNaclFast.java
+++ b/src/com/iwebpp/crypto/TweetNaclFast.java
@@ -83,20 +83,14 @@ public final class TweetNaclFast {
 		 * */
 		public byte [] box(byte [] message) {
 			if (message==null) return null;
-
-			// prepare shared key
-			if (this.sharedKey == null) before();
-
-			return after(message, 0, message.length);
+		  return box(message, 0, message.length);
 		}
+
 		public byte [] box(byte [] message, final int moff) {
 			if (!(message!=null && message.length>moff)) return null;
-
-			// prepare shared key
-			if (this.sharedKey == null) before();
-
-			return after(message, moff, message.length-moff);
+		  return box(message, moff, message.length-moff);
 		}
+	
 		public byte [] box(byte [] message, final int moff, final int mlen) {
 			if (!(message!=null && message.length>=(moff+mlen))) return null;
 
@@ -104,6 +98,38 @@ public final class TweetNaclFast {
 			if (this.sharedKey == null) before();
 
 			return after(message, moff, mlen);
+		}
+
+		/*
+		 * @description 
+		 *   Encrypt and authenticates message using peer's public key, 
+		 *   our secret key, and the given nonce, which must be unique 
+		 *   for each distinct message for a key pair.
+		 *
+		 *   Explicitly pass the nonce
+		 *   
+		 *   Returns an encrypted and authenticated message, 
+		 *   which is nacl.box.overheadLength longer than the original message.
+		 * */
+		public byte [] box(byte [] message, byte [] theNonce) {
+			if (message==null) return null;
+		  return box(message, 0, message.length, theNonce);
+		}
+
+		public byte [] box(byte [] message, final int moff, byte [] theNonce) {
+			if (!(message!=null && message.length>moff)) return null;
+		  return box(message, moff, message.length-moff, theNonce);
+		}
+	
+		public byte [] box(byte [] message, final int moff, final int mlen, byte [] theNonce) {
+			if (!(message!=null && message.length>=(moff+mlen) &&
+			      theNonce!=null && theNonce.length==nonceLength)) 
+			  return null;
+
+			// prepare shared key
+			if (this.sharedKey == null) before();
+
+			return after(message, moff, mlen, theNonce);
 		}
 
 		/*
@@ -138,6 +164,46 @@ public final class TweetNaclFast {
 			return open_after(box, boxoff, boxlen);
 		}
 
+
+		/*
+		 * @description 
+		 *   Authenticates and decrypts the given box with peer's public key, 
+		 *   our secret key, and the given nonce.
+		 *   Explicit passing of nonce
+		 *   Returns the original message, or null if authentication fails.
+		 * */
+		public byte [] open(byte [] box, byte [] theNonce) {
+			if (!(box!=null &&
+			      theNonce!=null && theNonce.length==nonceLength))
+			  return null;
+
+			// prepare shared key
+			if (this.sharedKey == null) before();
+
+			return open_after(box, 0, box.length, theNonce);
+		}
+		public byte [] open(byte [] box, final int boxoff, byte [] theNonce) {
+			if (!(box!=null && box.length>boxoff &&
+			      theNonce!=null && theNonce.length==nonceLength))
+			  return null;
+
+			// prepare shared key
+			if (this.sharedKey == null) before();
+
+			return open_after(box, boxoff, box.length-boxoff, theNonce);
+		}
+		public byte [] open(byte [] box, final int boxoff, final int boxlen, byte [] theNonce) {
+			if (!(box!=null && box.length>=(boxoff+boxlen) &&
+			      theNonce!=null && theNonce.length==nonceLength))
+			  return null;
+
+			// prepare shared key
+			if (this.sharedKey == null) before();
+
+			return open_after(box, boxoff, boxlen, theNonce);
+		}
+
+
 		/*
 		 * @description 
 		 *   Returns a precomputed shared key 
@@ -157,12 +223,19 @@ public final class TweetNaclFast {
 		 *   Same as nacl.box, but uses a shared key precomputed with nacl.box.before.
 		 * */
 		public byte [] after(byte [] message, final int moff, final int mlen) {
-			// check message
-			if (!(message!=null && message.length>=(moff+mlen)))
-				return null;
+		  return after(message, moff, mlen, generateNonce());
+		}
 
-			// generate nonce
-			byte [] n = generateNonce();
+		/*
+		 * @description 
+		 *   Same as nacl.box, but uses a shared key precomputed with nacl.box.before,
+		 *   and passes a nonce explicitly.
+		 * */
+		public byte [] after(byte [] message, final int moff, final int mlen, byte [] theNonce) {
+			// check message
+			if (!(message!=null && message.length>=(moff+mlen) &&
+			      theNonce!=null && theNonce.length==nonceLength))
+				return null;
 
 			// message buffer
 			byte [] m = new byte[mlen + zerobytesLength];
@@ -173,7 +246,7 @@ public final class TweetNaclFast {
 			for (int i = 0; i < mlen; i ++)
 				m[i+zerobytesLength] = message[i+moff];
 
-			if (0 != crypto_box_afternm(c, m, m.length, n, sharedKey))
+			if (0 != crypto_box_afternm(c, m, m.length, theNonce, sharedKey))
 				return null;
 
 			// wrap byte_buf_t on c offset@boxzerobytesLength
@@ -192,12 +265,13 @@ public final class TweetNaclFast {
 		 *   but uses a shared key pre-computed with nacl.box.before.
 		 * */
 		public byte [] open_after(byte [] box, final int boxoff, final int boxlen) {
+		  return open_after(box, boxoff, boxlen, generateNonce());
+		}
+		
+		public byte [] open_after(byte [] box, final int boxoff, final int boxlen, byte [] theNonce) {
 			// check message
 			if (!(box!=null && box.length>=(boxoff+boxlen) && boxlen>=boxzerobytesLength))
 				return null;
-
-			// generate nonce
-			byte [] n = generateNonce();
 
 			// cipher buffer
 			byte [] c = new byte[boxlen + boxzerobytesLength];
@@ -208,7 +282,7 @@ public final class TweetNaclFast {
 			for (int i = 0; i < boxlen; i++) 
 				c[i+boxzerobytesLength] = box[i+boxoff];
 
-			if (crypto_box_open_afternm(m, c, c.length, n, sharedKey) != 0) 
+			if (crypto_box_open_afternm(m, c, c.length, theNonce, sharedKey) != 0) 
 				return null;
 
 			// wrap byte_buf_t on m offset@zerobytesLength
@@ -367,21 +441,36 @@ public final class TweetNaclFast {
 		 * */
 		public byte [] box(byte [] message) {
 			if (message==null) return null;
-
 			return box(message, 0, message.length);
 		}
+		
 		public byte [] box(byte [] message, final int moff) {
 			if (!(message!=null && message.length>moff)) return null;
-
 			return box(message, moff, message.length-moff);
 		}
+		
 		public byte [] box(byte [] message, final int moff, final int mlen) {
 			// check message
 			if (!(message!=null && message.length>=(moff+mlen)))
 				return null;
+			return box(message, moff, message.length-moff, generateNonce());
+		}
 
-			// generate nonce
-			byte [] n = generateNonce();
+		public byte [] box(byte [] message, byte [] theNonce) {
+			if (message==null) return null;
+			return box(message, 0, message.length, theNonce);
+		}
+		
+		public byte [] box(byte [] message, final int moff, byte [] theNonce) {
+			if (!(message!=null && message.length>moff)) return null;
+			return box(message, moff, message.length-moff, theNonce);
+		}
+		
+		public byte [] box(byte [] message, final int moff, final int mlen, byte [] theNonce) {
+			// check message
+			if (!(message!=null && message.length>=(moff+mlen) &&
+			      theNonce!=null && theNonce.length==nonceLength))
+				return null;
 
 			// message buffer
 			byte [] m = new byte[mlen + zerobytesLength];
@@ -392,7 +481,7 @@ public final class TweetNaclFast {
 			for (int i = 0; i < mlen; i ++)
 				m[i+zerobytesLength] = message[i+moff];
 
-			if (0 != crypto_secretbox(c, m, m.length, n, key))
+			if (0 != crypto_secretbox(c, m, m.length, theNonce, key))
 				return null;
 
 			// TBD optimizing ...
@@ -415,21 +504,36 @@ public final class TweetNaclFast {
 		 * */
 		public byte [] open(byte [] box) {
 			if (box==null) return null;
-
 			return open(box, 0, box.length);
 		}
+		
 		public byte [] open(byte [] box, final int boxoff) {
 			if (!(box!=null && box.length>boxoff)) return null;
-
 			return open(box, boxoff, box.length-boxoff);
 		}	
+		
 		public byte [] open(byte [] box, final int boxoff, final int boxlen) {
 			// check message
 			if (!(box!=null && box.length>=(boxoff+boxlen) && boxlen>=boxzerobytesLength))
 				return null;
-
-			// generate nonce
-			byte [] n = generateNonce();
+			return open(box, boxoff, box.length-boxoff, generateNonce());
+    }
+    
+		public byte [] open(byte [] box, byte [] theNonce) {
+			if (box==null) return null;
+			return open(box, 0, box.length, theNonce);
+		}
+		
+		public byte [] open(byte [] box, final int boxoff, byte [] theNonce) {
+			if (!(box!=null && box.length>boxoff)) return null;
+			return open(box, boxoff, box.length-boxoff, theNonce);
+		}	
+		
+		public byte [] open(byte [] box, final int boxoff, final int boxlen, byte [] theNonce) {
+			// check message
+			if (!(box!=null && box.length>=(boxoff+boxlen) && boxlen>=boxzerobytesLength &&
+			      theNonce!=null && theNonce.length==nonceLength))
+				return null;
 
 			// cipher buffer
 			byte [] c = new byte[boxlen + boxzerobytesLength];
@@ -440,7 +544,7 @@ public final class TweetNaclFast {
 			for (int i = 0; i < boxlen; i++) 
 				c[i+boxzerobytesLength] = box[i+boxoff];
 
-			if (0 != crypto_secretbox_open(m, c, c.length, n, key))
+			if (0 != crypto_secretbox_open(m, c, c.length, theNonce, key))
 				return null;
 
 			// wrap byte_buf_t on m offset@zerobytesLength
@@ -3209,7 +3313,7 @@ public final class TweetNaclFast {
 	 * */
 	private static final SecureRandom jrandom = new SecureRandom();
 
-	private static void randombytes(byte [] x, int len) {
+	public static void randombytes(byte [] x, int len) {
 		int ret = len % 8;
 		long rnd;
 

--- a/src/com/iwebpp/crypto/tests/TweetNaclTest.java
+++ b/src/com/iwebpp/crypto/tests/TweetNaclTest.java
@@ -134,10 +134,10 @@ public final class TweetNaclTest {
 		Log.d(TAG, "pkbt: "+pkbt);
 		
 		// peer A -> B
-		TweetNacl.Box pab = new TweetNacl.Box(kb.getPublicKey(), ka.getSecretKey(), 0);
+		TweetNacl.Box pab = new TweetNacl.Box(kb.getPublicKey(), ka.getSecretKey());
 
 		// peer B -> A
-		TweetNacl.Box pba = new TweetNacl.Box(ka.getPublicKey(), kb.getSecretKey(), 0);
+		TweetNacl.Box pba = new TweetNacl.Box(ka.getPublicKey(), kb.getSecretKey());
 
 		// messages
 		String m0 = "Helloword, Am Tom ...";
@@ -265,10 +265,10 @@ public final class TweetNaclTest {
 			shk[i] = 0x66;
 
 		// peer A -> B
-		TweetNacl.SecretBox pab = new TweetNacl.SecretBox(shk, 0);
+		TweetNacl.SecretBox pab = new TweetNacl.SecretBox(shk);
 
 		// peer B -> A
-		TweetNacl.SecretBox pba = new TweetNacl.SecretBox(shk, 0);
+		TweetNacl.SecretBox pba = new TweetNacl.SecretBox(shk);
 
 		// messages
 		String m0 = "Helloword, Am Tom ...";


### PR DESCRIPTION
…fter, and open_after,  and  for SecretBox' box and open, that pass an explicit byte[] nonce value to provide better interop with the other Nacl implementations. - similarly to the previous changes to TweetNacl.java.

Added test cases to TweetNaclFastTest.java that use the explicit passing of a nonce byte[] value.
Added short example to README.md.