### PR TITLE
TweetNaclFast.java :

### DIFF
--- a/src/com/iwebpp/crypto/TweetNaclFast.java
+++ b/src/com/iwebpp/crypto/TweetNaclFast.java
@@ -5,6 +5,8 @@ package com.iwebpp.crypto;
 
 import java.io.UnsupportedEncodingException;
 import java.security.SecureRandom;
+import java.util.Base64;
+import java.lang.System;
 import java.util.concurrent.atomic.AtomicLong;
 
 
@@ -3313,7 +3315,23 @@ public final class TweetNaclFast {
 	 * */
 	private static final SecureRandom jrandom = new SecureRandom();
 
-	public static void randombytes(byte [] x, int len) {
+	public static byte[] randombytes(byte [] x) {
+	  jrandom.nextBytes(x);
+	  return x;
+	}
+	
+	public static byte[] randombytes(int len) {
+	  return randombytes(new byte[len]);
+	}
+	
+	public static byte[] randombytes(byte [] x, int len) {
+    byte [] b = randombytes(len);
+    System.arraycopy(b, 0, x, 0, len);
+    return x;
+	}
+	
+/*
+  public static byte[] randombytes(byte [] x, int len) {
 		int ret = len % 8;
 		long rnd;
 
@@ -3335,6 +3353,47 @@ public final class TweetNaclFast {
 			for (int i = len-ret; i < len; i ++)
 				x[i] = (byte) (rnd >>> 8*i);
 		}
+		return x;
 	}
+*/
 
+	public static byte[] makeBoxNonce() {
+	  return randombytes(Box.nonceLength);
+	}
+	
+	public static byte[] makeSecretBoxNonce() {
+	  return randombytes(SecretBox.nonceLength);
+	}
+	
+	public static String base64EncodeToString(byte [] b) {
+	  return Base64.getUrlEncoder().withoutPadding().encodeToString(b);
+	}
+	// byte[] Base64.getUrlEncoder().withoutPadding().encode(b);
+	
+	public static byte[] base64Decode(String s) {
+	  return Base64.getUrlDecoder().decode(s);
+	}
+	// byte[] Base64.getUrlDecoder().decode(byte[] b)
+	
+  public static String hexEncodeToString( byte [] raw ) {
+    String HEXES = "0123456789ABCDEF";
+    final StringBuilder hex = new StringBuilder( 2 * raw.length );
+    for ( final byte b : raw ) {
+      hex.append(HEXES.charAt((b & 0xF0) >> 4))
+         .append(HEXES.charAt((b & 0x0F)));
+    }
+    return hex.toString();
+  }
+
+  public static byte[] hexDecode(String s) {
+    byte[] b = new byte[s.length() / 2];
+    for (int i = 0; i < s.length(); i += 2) {
+      b[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
+                           + Character.digit(s.charAt(i+1), 16));
+    }
+    return b;
+  }
+
+	// public static boolean java.util.Arrays.equals(array1, array2);
+		
 }

--- a/src/com/iwebpp/crypto/tests/TweetNaclFastTest.java
+++ b/src/com/iwebpp/crypto/tests/TweetNaclFastTest.java
@@ -1,14 +1,13 @@
 package com.iwebpp.crypto.tests;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
 
 import com.iwebpp.crypto.TweetNaclFast;
-import static com.iwebpp.crypto.TweetNaclFast.Box.nonceLength;
-
 
 public final class TweetNaclFastTest {
 	private static final String TAG = "TweetNaclFastTest";
-
+	
 	private boolean testBox() throws UnsupportedEncodingException {
 		// keypair A
 		byte [] ska = new byte[32]; for (int i = 0; i < 32; i ++) ska[i] = 0;
@@ -18,6 +17,7 @@ public final class TweetNaclFastTest {
 		for (int i = 0; i < ka.getSecretKey().length; i ++)
 			skat += " "+ka.getSecretKey()[i];
 		Log.d(TAG, "skat: "+skat);
+		
 		
 		String pkat = "";
 		for (int i = 0; i < ka.getPublicKey().length; i ++)
@@ -96,13 +96,21 @@ public final class TweetNaclFastTest {
 	private boolean testBoxNonce() throws UnsupportedEncodingException {
 	
 		// explicit nonce
-    byte [] theNonce = new byte[nonceLength]; 
-    com.iwebpp.crypto.TweetNaclFast.randombytes(theNonce, nonceLength);
+    byte [] theNonce = TweetNaclFast.makeBoxNonce();
+		byte [] theNonce2 = TweetNaclFast.base64Decode(
+		                      TweetNaclFast.base64EncodeToString(theNonce));
+		Log.d(TAG, "BoxNonce Base64 test Equal: " + "\"" + java.util.Arrays.equals(theNonce, theNonce2) + "\"");
+		byte [] theNonce3 = TweetNaclFast.hexDecode(
+		                      TweetNaclFast.hexEncodeToString(theNonce));
+		Log.d(TAG, "BoxNonce Hex test Equal: " + "\"" + java.util.Arrays.equals(theNonce, theNonce3) + "\"");
 		String theNoncet = "";
 		for (int i = 0; i < theNonce.length; i ++)
 			theNoncet += " "+theNonce[i];
 		Log.d(TAG, "BoxNonce: "+theNoncet);
-	
+		Log.d(TAG, "BoxNonce: " + "\"" + TweetNaclFast.base64EncodeToString(theNonce) + "\"");
+		Log.d(TAG, "BoxNonce: " + "\"" + TweetNaclFast.hexEncodeToString(theNonce) + "\"");
+                 
+		
 
 		// keypair A
 		byte [] ska = new byte[32]; for (int i = 0; i < 32; i ++) ska[i] = 0;
@@ -250,8 +258,7 @@ public final class TweetNaclFastTest {
 	private boolean testSecretBoxNonce() throws UnsupportedEncodingException {
 		
 		// explicit nonce
-    byte [] theNonce = new byte[nonceLength]; 
-    com.iwebpp.crypto.TweetNaclFast.randombytes(theNonce, nonceLength);
+    byte [] theNonce = TweetNaclFast.makeSecretBoxNonce();
 		String theNoncet = "";
 		for (int i = 0; i < theNonce.length; i ++)
 			theNoncet += " "+theNonce[i];


### PR DESCRIPTION
* modified and added randombytes() methods  to return the random byte array with convenience randombytes(int len) and randombytes(byte[] b).
* added makeBoxNonce() and makeSecretBoxNonce() to make it easier to generate a correct nonce value (even though those nonce sizes happen to be the same...
* added base64EncodeToString(), base64Decode(), hexEncodeToString(), hexDecode(), to facilitate the common encoding formats for byte[]'s
* added a few tests for the newly defined methods