### PR TITLE
Signature.detached() and Signature.detached_verify()

### DIFF
--- a/src/com/iwebpp/crypto/TweetNacl.java
+++ b/src/com/iwebpp/crypto/TweetNacl.java
@@ -2299,7 +2299,7 @@ public final class TweetNacl {
 		M(chk,0,chk.length, chk,0,chk.length, den,0,den.length);
 		if (neq25519(chk, num)!=0) return -1;
 
-		if (par25519(r[0]) == (p[31]>>7)) Z(r[0],0,r[0].length, gf0,0,gf0.length, r[0],0,r[0].length);
+		if (par25519(r[0]) == ((p[31]&0xFF)>>7)) Z(r[0],0,r[0].length, gf0,0,gf0.length, r[0],0,r[0].length);
 
 		M(r[3],0,r[3].length, r[0],0,r[0].length, r[1],0,r[1].length);
 		return 0;

--- a/src/com/iwebpp/crypto/TweetNacl.java
+++ b/src/com/iwebpp/crypto/TweetNacl.java
@@ -695,8 +695,11 @@ public final class TweetNacl {
 		 *   Signs the message using the secret key and returns a signature.
 		 * */
 		public byte [] detached(byte [] message) {
-
-			return null;
+			byte[] signedMsg = this.sign(message);
+			byte[] sig = new byte[signatureLength];
+			for (int i = 0; i < sig.length; i++)
+				sig[i] = signedMsg[i];
+			return sig;
 		}
 
 		/*
@@ -705,8 +708,17 @@ public final class TweetNacl {
 		 *   returns true if verification succeeded or false if it failed.
 		 * */
 		public boolean detached_verify(byte [] message, byte [] signature) {
-
-			return false;
+			if (signature.length != signatureLength)
+				return false;
+			if (theirPublicKey.length != publicKeyLength)
+				return false;
+			byte [] sm = new byte[signatureLength + message.length];
+			byte [] m = new byte[signatureLength + message.length];
+			for (int i = 0; i < signatureLength; i++)
+				sm[i] = signature[i];
+			for (int i = 0; i < message.length; i++)
+				sm[i + signatureLength] = message[i];
+			return (crypto_sign_open(m, -1, sm, sm.length, theirPublicKey) >= 0);
 		}
 
 		/*

--- a/src/com/iwebpp/crypto/TweetNaclFast.java
+++ b/src/com/iwebpp/crypto/TweetNaclFast.java
@@ -3262,7 +3262,7 @@ public final class TweetNaclFast {
 		M(chk, chk, den);
 		if (neq25519(chk, num)!=0) return -1;
 
-		if (par25519(r[0]) == (p[31]>>>7)) Z(r[0], gf0, r[0]);
+		if (par25519(r[0]) == ((p[31]&0xFF)>>>7)) Z(r[0], gf0, r[0]);
 
 		M(r[3], r[0], r[1]);
 

--- a/src/com/iwebpp/crypto/TweetNaclFast.java
+++ b/src/com/iwebpp/crypto/TweetNaclFast.java
@@ -762,8 +762,11 @@ public final class TweetNaclFast {
 		 *   Signs the message using the secret key and returns a signature.
 		 * */
 		public byte [] detached(byte [] message) {
-
-			return null;
+			byte[] signedMsg = this.sign(message);
+			byte[] sig = new byte[signatureLength];
+			for (int i = 0; i < sig.length; i++)
+				sig[i] = signedMsg[i];
+			return sig;
 		}
 
 		/*
@@ -772,8 +775,17 @@ public final class TweetNaclFast {
 		 *   returns true if verification succeeded or false if it failed.
 		 * */
 		public boolean detached_verify(byte [] message, byte [] signature) {
-
-			return false;
+			if (signature.length != signatureLength)
+				return false;
+			if (theirPublicKey.length != publicKeyLength)
+				return false;
+			byte [] sm = new byte[signatureLength + message.length];
+			byte [] m = new byte[signatureLength + message.length];
+			for (int i = 0; i < signatureLength; i++)
+				sm[i] = signature[i];
+			for (int i = 0; i < message.length; i++)
+				sm[i + signatureLength] = message[i];
+			return (crypto_sign_open(m, -1, sm, 0, sm.length, theirPublicKey) >= 0);
 		}
 
 		/*

--- a/src/com/iwebpp/crypto/tests/TweetNaclFastTest.java
+++ b/src/com/iwebpp/crypto/tests/TweetNaclFastTest.java
@@ -524,7 +524,34 @@ public final class TweetNaclFastTest {
 		
 		return true;
 	}
-	
+
+	private boolean testSignDetached(String seedStr) throws UnsupportedEncodingException {
+		Log.d(TAG, "seed:@" + System.currentTimeMillis());
+
+		byte[] seed = TweetNaclFast.hexDecode(seedStr);
+		TweetNaclFast.Signature.KeyPair kp = TweetNaclFast.Signature.keyPair_fromSeed(seed);
+
+		String testString = "test string";
+		byte[] bytes = testString.getBytes();
+
+		TweetNaclFast.Signature s1 = new TweetNaclFast.Signature(null, kp.getSecretKey());
+		Log.d(TAG, "\ndetached...@" + System.currentTimeMillis());
+		byte[] signature = s1.detached(bytes);
+		Log.d(TAG, "...detached@" + System.currentTimeMillis());
+
+		TweetNaclFast.Signature s2 = new TweetNaclFast.Signature(kp.getPublicKey(), null);
+		Log.d(TAG, "\nverify...@" + System.currentTimeMillis());
+		boolean result = s2.detached_verify(bytes,  signature);
+		Log.d(TAG, "...verify@" + System.currentTimeMillis());
+
+		if(result) {
+			Log.d(TAG, "verify success @" + testString);
+		} else {
+			Log.e(TAG, "verify failed @" + testString);
+		}
+
+		return  true;
+	}
 	/*
 	 * bench test using tweetnacl.c, tweetnacl.js result
 	 * */
@@ -541,13 +568,16 @@ public final class TweetNaclFastTest {
 				try {
 					///testSecretBox();
 					///testSecretBoxNonce();
-					testBox();
+					///testBox();
 					///testBoxNonce();
 					///testBoxKalium();
 					
 					///testHash();
 					///testSign();
-					
+
+					testSignDetached("ac49000da11249ea3510941703a7e21a39837c4d2d5300daebbd532df20f8135");
+					testSignDetached("e56f0eef73ade8f79bc1d16a99cbc5e4995afd8c14adb49410ecd957aecc8d02");
+
 					///testBench();
 				} catch (UnsupportedEncodingException e) {
 					// TODO Auto-generated catch block

--- a/src/com/iwebpp/crypto/tests/TweetNaclTest.java
+++ b/src/com/iwebpp/crypto/tests/TweetNaclTest.java
@@ -5,6 +5,8 @@ package com.iwebpp.crypto.tests;
 
 import java.io.UnsupportedEncodingException;
 import com.iwebpp.crypto.TweetNacl;
+import com.iwebpp.crypto.TweetNaclFast;
+
 import static com.iwebpp.crypto.TweetNacl.Box.nonceLength;
 
 public final class TweetNaclTest {
@@ -423,7 +425,34 @@ public final class TweetNaclTest {
 		
 		return true;
 	}
-	
+
+	private boolean testSignDetached(String seedStr) throws UnsupportedEncodingException {
+		Log.d(TAG, "seed:@" + System.currentTimeMillis());
+
+		byte[] seed = TweetNaclFast.hexDecode(seedStr);
+		TweetNacl.Signature.KeyPair kp = TweetNacl.Signature.keyPair_fromSeed(seed);
+
+		String testString = "test string";
+		byte[] bytes = testString.getBytes();
+
+		TweetNacl.Signature s1 = new TweetNacl.Signature(null, kp.getSecretKey());
+		Log.d(TAG, "\ndetached...@" + System.currentTimeMillis());
+		byte[] signature = s1.detached(bytes);
+		Log.d(TAG, "...detached@" + System.currentTimeMillis());
+
+		TweetNacl.Signature s2 = new TweetNacl.Signature(kp.getPublicKey(), null);
+		Log.d(TAG, "\nverify...@" + System.currentTimeMillis());
+		boolean result = s2.detached_verify(bytes,  signature);
+		Log.d(TAG, "...verify@" + System.currentTimeMillis());
+
+		if(result) {
+			Log.d(TAG, "verify success @" + testString);
+		} else {
+			Log.e(TAG, "verify failed @" + testString);
+		}
+
+		return  true;
+	}
 	/*
 	 * bench test using tweetnacl.c, tweetnacl.js result
 	 * */
@@ -445,7 +474,8 @@ public final class TweetNaclTest {
 					
 					testHash();
 					testSign();
-					
+					testSignDetached("ac49000da11249ea3510941703a7e21a39837c4d2d5300daebbd532df20f8135");
+					testSignDetached("e56f0eef73ade8f79bc1d16a99cbc5e4995afd8c14adb49410ecd957aecc8d02");
 					///testBench();
 				} catch (UnsupportedEncodingException e) {
 					// TODO Auto-generated catch block


### PR DESCRIPTION
Added implementation Signature.detached() and Signature.detached_verify() methods in TweetNacl and TweetNaclFast (implementation based on JS-fork https://github.com/dchest/tweetnacl-js).
Fixed an implicit extension byte in unpackneg() function in TweetNacl and TweetNaclFast (detached_verify give false-negative results).