### PR TITLE
fix bitwise operation bug

### DIFF
--- a/src/main/java/com/iwebpp/crypto/TweetNacl.java
+++ b/src/main/java/com/iwebpp/crypto/TweetNacl.java
@@ -906,7 +906,7 @@ public final class TweetNacl {
 			int n)
 	{
 		int i,d = 0;
-		for (i = 0; i < n; i ++) d |= (x[i+xoff]^y[i+yoff]) & 0xff;
+		for (i = 0; i < n; i ++) d |= (x[i+xoff]^y[i+yoff]);
 		return (1 & ((d - 1) >>> 8)) - 1;
 	}
 

--- a/src/main/java/com/iwebpp/crypto/TweetNaclFast.java
+++ b/src/main/java/com/iwebpp/crypto/TweetNaclFast.java
@@ -957,7 +957,7 @@ public final class TweetNaclFast {
 			int n)
 	{
 		int i,d = 0;
-		for (i = 0; i < n; i ++) d |= (x[i+xoff]^y[i+yoff]) & 0xff;
+		for (i = 0; i < n; i ++) d |= (x[i+xoff]^y[i+yoff]);
 		return (1 & ((d - 1) >>> 8)) - 1;
 	}
 


### PR DESCRIPTION
d should be defined as byte cause of x,y are defined as byte array. but remove `& 0xff` also works in bitwise operation.